### PR TITLE
[clang-tidy] Add Mesos check that lambdas capturing `this` are always dispatched/deferred.

### DIFF
--- a/clang-tidy/mesos/CMakeLists.txt
+++ b/clang-tidy/mesos/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS support)
 add_clang_library(clangTidyMesosModule
   MesosTidyModule.cpp
   NamespaceCommentCheck.cpp
+  ThisCaptureCheck.cpp
 
   LINK_LIBS
   clangAST

--- a/clang-tidy/mesos/MesosTidyModule.cpp
+++ b/clang-tidy/mesos/MesosTidyModule.cpp
@@ -10,7 +10,9 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+
 #include "NamespaceCommentCheck.h"
+#include "ThisCaptureCheck.h"
 
 namespace clang {
 namespace tidy {
@@ -21,6 +23,7 @@ public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
     CheckFactories.registerCheck<NamespaceCommentCheck>(
         "mesos-namespace-comment");
+    CheckFactories.registerCheck<ThisCaptureCheck>("mesos-this-capture");
   }
 };
 

--- a/clang-tidy/mesos/ThisCaptureCheck.cpp
+++ b/clang-tidy/mesos/ThisCaptureCheck.cpp
@@ -1,0 +1,55 @@
+//===--- ThisCaptureCheck.cpp - clang-tidy---------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ThisCaptureCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
+  const auto dispatcher = callExpr(
+      hasDeclaration(namedDecl(anyOf(hasName("defer"), hasName("dispatch")))));
+
+  const auto undeferredLambda =
+      lambdaExpr(hasDescendant(cxxThisExpr()), unless(hasAncestor(dispatcher)));
+
+  const auto futureCallbackName = anyOf(
+      hasName("after"),
+      hasName("onAny"),
+      hasName("onDiscard"),
+      hasName("onDiscarded"),
+      hasName("onFailed"),
+      hasName("onReady"),
+      hasName("repair"),
+      hasName("then"));
+
+  Finder->addMatcher(
+      cxxMemberCallExpr(hasDeclaration(namedDecl(futureCallbackName)),
+                        hasDescendant(undeferredLambda.bind("lambda"))),
+      this);
+}
+
+void ThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *lambda = Result.Nodes.getNodeAs<LambdaExpr>("lambda");
+
+  if (not lambda)
+    return;
+
+  diag(lambda->getLocStart(), "callback capturing this should be "
+                              "dispatched/deferred to a specific PID");
+}
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang

--- a/clang-tidy/mesos/ThisCaptureCheck.h
+++ b/clang-tidy/mesos/ThisCaptureCheck.h
@@ -1,0 +1,35 @@
+//===--- ThisCaptureCheck.h - clang-tidy-------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_THIS_CAPTURE_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_THIS_CAPTURE_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/mesos-this-capture.html
+class ThisCaptureCheck : public ClangTidyCheck {
+public:
+  ThisCaptureCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_THIS_CAPTURE_H

--- a/docs/clang-tidy/checks/list.rst
+++ b/docs/clang-tidy/checks/list.rst
@@ -42,6 +42,7 @@ Clang-Tidy Checks
    llvm-include-order
    llvm-namespace-comment
    llvm-twine-local
+   mesos-this-capture
    misc-argument-comment
    misc-assert-side-effect
    misc-assign-operator-signature

--- a/docs/clang-tidy/checks/mesos-this-capture.rst
+++ b/docs/clang-tidy/checks/mesos-this-capture.rst
@@ -1,0 +1,7 @@
+.. title:: clang-tidy - mesos-this-capture
+
+mesos-this-capture
+==================
+
+`Futures` accessing internal object state through `this` should always be
+executed on a dedicated actor to control lifetime and avoid races.

--- a/test/clang-tidy/mesos-this-capture.cpp
+++ b/test/clang-tidy/mesos-this-capture.cpp
@@ -1,0 +1,62 @@
+// RUN: %check_clang_tidy %s mesos-this-capture %t
+
+namespace process {
+template <typename>
+struct Future {
+  template <typename F> Future onAny(F) { return {}; };
+  template <typename F> Future then(F) { return {}; };
+};
+
+template <typename F>
+Future<void> defer(int pid, F) { return {}; }
+
+} // namespace process  {
+
+using process::Future;
+using process::defer;
+
+struct S {
+  Future<void> future() const { return {}; }
+
+  // TODO(bbannier): Rework matcher to check all branches of a chained Future.
+
+  void f() {
+    future()
+        // CHECK-MESSAGES: :[[@LINE+1]]:15: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+        .then([this]() { (void)this; });
+    future()
+        // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+        .onAny([this]() { (void)this; });
+    }
+
+    void g() {
+      future()
+          // CHECK-MESSAGES: :[[@LINE+1]]:17: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+          .then([=]() { (void)this; });
+      future()
+          // CHECK-MESSAGES: :[[@LINE+1]]:18: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+          .onAny([=]() { (void)this->i; });
+    }
+
+    // TODO(bbannier): Check referenced lambda.
+    // void h() {
+    //   auto l = [=]() { (void)this; };
+    //   // DISABLEDCHECK-MESSAGES: :[[@LINE+1]]:21: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    //   future().then(l);
+    // }
+
+    int i = 0;
+};
+
+// Negatives.
+void f() {
+  Future<void>().onAny([]() {});
+  Future<void>().then([]() {});
+};
+
+struct K {
+    void f() {
+      Future<void>()
+          .then(defer(0, [=]() { (void)this; }));
+    }
+};


### PR DESCRIPTION
This adds a clang-tidy check which catches instances where lambdas capturing `this` are not explicitly dispatched or deferred when registering callbacks on `Future`s. Currently we do not diagnose cases where the lambda is not declare at the spot, e.g.,

``` cpp
auto l = [this](...) {};

Future<int> f = ...
f.then(l);  // NOT DIAGNOSED WITH THIS PATCH
```

We add a number of test cases. These are run via the `check-clang-tools` target and all pass. Note that that target does currently not run cleanly due to failures in the `MesosNamespaceCommentCheckTest` test.
