### PR TITLE
[clang-tidy] Made `mesos-this-capture` check tighter.

### DIFF
--- a/clang-tidy/mesos/ThisCaptureCheck.cpp
+++ b/clang-tidy/mesos/ThisCaptureCheck.cpp
@@ -11,18 +11,25 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace clang::ast_matchers;
 
 namespace clang {
 namespace tidy {
 namespace mesos {
 
+AST_MATCHER(LambdaExpr, capturesThis) {
+  return llvm::any_of(Node.captures(),
+                      [](const LambdaCapture &c) { return c.capturesThis(); });
+}
+
 void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
   const auto dispatcher = callExpr(
       hasDeclaration(namedDecl(anyOf(hasName("defer"), hasName("dispatch")))));
 
   const auto undeferredLambda =
-      lambdaExpr(hasDescendant(cxxThisExpr()), unless(hasAncestor(dispatcher)));
+      lambdaExpr(capturesThis(), unless(hasAncestor(dispatcher)));
 
   const auto futureCallbackName = anyOf(
       hasName("after"),
@@ -36,6 +43,7 @@ void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
 
   Finder->addMatcher(
       cxxMemberCallExpr(hasDeclaration(namedDecl(futureCallbackName)),
+                        on(hasType(cxxRecordDecl(hasName("Future")))),
                         hasDescendant(undeferredLambda.bind("lambda"))),
       this);
 }


### PR DESCRIPTION
Improve the `mesos-this-capture` to remove false positives. This was
triggered by the following example,

  https://github.com/apache/mesos/blob/d2117362349ab4c383045720f77d42b2d9fd6871/src/slave/containerizer/mesos/io/switchboard.cpp#L1487

In its old form the matcher did not make sure that the found undeferred lambda
actually captured `this`, but instead triggered on any lambda containing
some `CXXThisExpr` in any descendant. This caused problems e.g., in the
case of nested lambdas where one lambda was undeferred while the other one
captured a `this`. With this change we make sure to check the correct
lambda for `this`-capture.

The matcher also did not make sure that the matched `CxxMemberCallExpr`s
where actually on some process `Future`. Added an `on` narrower to
ensure this.

We still use a weakly constrained traversal matchers (`hasDescendant`,
`hasAncestor`) in this check, but this currently triggers no false positives in
the Mesos code base.