### PR TITLE
[clang-tidy] Added Mesos check of custom Flags classes.

### DIFF
--- a/clang-tidy/mesos/CMakeLists.txt
+++ b/clang-tidy/mesos/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS support)
 
 add_clang_library(clangTidyMesosModule
+  FlagsCheck.cpp
   MesosTidyModule.cpp
   NamespaceCommentCheck.cpp
   ThisCaptureCheck.cpp

--- a/clang-tidy/mesos/FlagsCheck.cpp
+++ b/clang-tidy/mesos/FlagsCheck.cpp
@@ -1,0 +1,69 @@
+//===--- FlagsCheck.cpp - clang-tidy---------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "FlagsCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+void FlagsCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(cxxRecordDecl(isDerivedFrom("FlagsBase")).bind("flags"),
+                     this);
+}
+
+namespace {
+bool isDerivedFromFlagsBase(const CXXRecordDecl &decl) {
+  return llvm::any_of(decl.bases(), [](const CXXBaseSpecifier &base) {
+    const auto *decl = base.getType()->getAsCXXRecordDecl();
+    return decl->getName() == "FlagsBase" || isDerivedFromFlagsBase(*decl);
+  });
+}
+}
+
+void FlagsCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *derivedDecl = Result.Nodes.getNodeAs<CXXRecordDecl>("flags");
+
+  // We explicitly iterate the bases here so we can emit diagnostic pointing to
+  // the exact inheritance introducing the issue.
+  for (auto &&base : derivedDecl->bases()) {
+    const auto *baseDecl = base.getType()->getAsCXXRecordDecl();
+
+    // First check if this inheritance is from 'FlagsBase' or any of its
+    // descendants.
+    if (baseDecl->getName() != "FlagsBase" &&
+        !isDerivedFromFlagsBase(*baseDecl)) {
+      continue;
+    }
+
+    // If the inheritance was 'virtual' there's nothing we need to do here.
+    if (base.isVirtual()) {
+      continue;
+    }
+
+    diag(base.getLocStart(), "'%0' does not inherit virtually from '%1'%2")
+        << derivedDecl->getName() << baseDecl->getName()
+        << FixItHint::CreateInsertion(base.getLocStart(), "virtual ")
+        << (baseDecl->getName() != "FlagsBase"
+                ? " which inherits from 'FlagsBase'"
+                : "");
+
+    // Break if we found a match so any FixIts are in the correct location.
+    // Rechecking after fixing the first issue might also find new issues as the
+    // hierarchy is changed.
+    break;
+  }
+}
+} // namespace mesos
+} // namespace tidy
+} // namespace clang

--- a/clang-tidy/mesos/FlagsCheck.h
+++ b/clang-tidy/mesos/FlagsCheck.h
@@ -1,0 +1,35 @@
+//===--- FlagsCheck.h - clang-tidy-------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_FLAGS_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_FLAGS_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/mesos-flags.html
+class FlagsCheck : public ClangTidyCheck {
+public:
+  FlagsCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_FLAGS_H

--- a/clang-tidy/mesos/MesosTidyModule.cpp
+++ b/clang-tidy/mesos/MesosTidyModule.cpp
@@ -11,6 +11,7 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 
+#include "FlagsCheck.h"
 #include "NamespaceCommentCheck.h"
 #include "ThisCaptureCheck.h"
 
@@ -21,6 +22,8 @@ namespace mesos {
 class MesosModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<FlagsCheck>(
+        "mesos-flags");
     CheckFactories.registerCheck<NamespaceCommentCheck>(
         "mesos-namespace-comment");
     CheckFactories.registerCheck<ThisCaptureCheck>("mesos-this-capture");

--- a/docs/clang-tidy/checks/list.rst
+++ b/docs/clang-tidy/checks/list.rst
@@ -50,6 +50,7 @@ Clang-Tidy Checks
    llvm-include-order
    llvm-namespace-comment
    llvm-twine-local
+   mesos-flags
    mesos-this-capture
    misc-argument-comment
    misc-assert-side-effect

--- a/docs/clang-tidy/checks/mesos-flags.rst
+++ b/docs/clang-tidy/checks/mesos-flags.rst
@@ -1,0 +1,11 @@
+.. title:: clang-tidy - mesos-flags
+
+mesos-flags
+===========
+
+Classes implementing flags parsing by inheriting stout's `flags::FlagBase`
+class should always use `virtual` inheritance on any path leading to
+`flags::FlagsBase`. This is required since the `FlagsBase` part of the flags
+class contains a map of flag names to `Flag` instances; `virtual` inheritance
+makes sure that only a single instance of the map is created so that all flags
+from base classes are set once and found correctly.

--- a/test/clang-tidy/mesos-flags.cpp
+++ b/test/clang-tidy/mesos-flags.cpp
@@ -1,0 +1,18 @@
+// RUN: %check_clang_tidy %s mesos-flags %t
+
+struct FlagsBase {};
+
+struct A : FlagsBase {};
+// CHECK-MESSAGES: :[[@LINE-1]]:12: warning: 'A' does not inherit virtually from 'FlagsBase' [mesos-flags]
+// CHECK-FIXES: {{^}}struct A : virtual FlagsBase {};{{$}}
+
+struct B : A {};
+// CHECK-MESSAGES: :[[@LINE-1]]:12: warning: 'B' does not inherit virtually from 'A' which inherits from 'FlagsBase' [mesos-flags]
+// CHECK-FIXES: {{^}}struct B : virtual A {};{{$}}
+
+class C : public FlagsBase {};
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: 'C' does not inherit virtually from 'FlagsBase' [mesos-flags]
+// CHECK-FIXES: {{^}}class C : virtual public FlagsBase {};{{$}}
+
+struct D : virtual FlagsBase {};
+struct E : virtual C {};


### PR DESCRIPTION
This change fixes MESOS-6320.