### PR TITLE
Fixed a couple issue in the mesos-this-capture check.

### DIFF
--- a/clang-tidy/mesos/ThisCaptureCheck.cpp
+++ b/clang-tidy/mesos/ThisCaptureCheck.cpp
@@ -70,6 +70,13 @@ void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
           on(hasType(cxxRecordDecl(hasName("Future")))),
           hasAnyArgument(anyOf(lambdaCapturingThis, lambdaCapturingThisRef))),
       this);
+
+  // Matcher for `process::loop`.
+  Finder->addMatcher(callExpr(callee(namedDecl(hasName("process::loop"))),
+                              hasAnyArgument(anyOf(
+                                  materializeTemporaryExpr(lambdaCapturingThis),
+                                  lambdaCapturingThisRef))),
+                     this);
 }
 
 void ThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tidy/mesos/ThisCaptureCheck.cpp
+++ b/clang-tidy/mesos/ThisCaptureCheck.cpp
@@ -25,12 +25,6 @@ AST_MATCHER(LambdaExpr, capturesThis) {
 }
 
 void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
-  const auto dispatcher = callExpr(
-      hasDeclaration(namedDecl(anyOf(hasName("defer"), hasName("dispatch")))));
-
-  const auto undeferredLambda =
-      lambdaExpr(capturesThis(), unless(hasAncestor(dispatcher)));
-
   const auto futureCallbackName = anyOf(
       hasName("after"),
       hasName("onAny"),
@@ -41,21 +35,56 @@ void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
       hasName("repair"),
       hasName("then"));
 
+  // A matcher for a this-capturing lambda.
+  const auto lambda = has(lambdaExpr(capturesThis()).bind("lambda"));
+
+  // Depending on whether the lambda captures additional variables with
+  // non-POD, non-trivial types, an additional `CXXBindTemporaryExpr` might be
+  // emitted.
+  const auto lambdaCapturingThis =
+      anyOf(lambda, has(cxxBindTemporaryExpr(lambda)));
+
+  // If the lambda is passed in and not directly defined as an argument a
+  // `DeclRefExpr` is emitted and we need to check to referenced variable.
+  //
+  // The variable will be constructed from some lambda expr, e.g.,
+  //
+  //     auto l = []() {};
+  //
+  // This sort of construction of class-type objects always emits an
+  // `ExprWithCleanups` with a `CXXConstructExpr` from a
+  // `MaterializeTemporaryExpr`.
+  const auto lambdaCapturingThisRef =
+      declRefExpr(
+          hasDeclaration(varDecl(has(exprWithCleanups(has(cxxConstructExpr(
+              has(materializeTemporaryExpr(lambdaCapturingThis)))))))))
+          .bind("ref");
+
+  // Register a matcher for this-capturing lambdas used directly to the `Future`
+  // callbacks. This matcher requires such a lambda or reference to such a
+  // lambda as arguments and e.g., does not match lambdas wrapped in `defer`
+  // invocations.
   Finder->addMatcher(
-      cxxMemberCallExpr(hasDeclaration(namedDecl(futureCallbackName)),
-                        on(hasType(cxxRecordDecl(hasName("Future")))),
-                        hasDescendant(undeferredLambda.bind("lambda"))),
+      cxxMemberCallExpr(
+          hasDeclaration(namedDecl(futureCallbackName)),
+          on(hasType(cxxRecordDecl(hasName("Future")))),
+          hasAnyArgument(anyOf(lambdaCapturingThis, lambdaCapturingThisRef))),
       this);
 }
 
 void ThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {
-  const auto *lambda = Result.Nodes.getNodeAs<LambdaExpr>("lambda");
+  const auto *ref = Result.Nodes.getNodeAs<Expr>("ref");
+  const auto *lambda = Result.Nodes.getNodeAs<Expr>("lambda");
 
-  if (not lambda)
-    return;
+  diag(ref ? ref->getLocStart() : lambda->getLocStart(),
+       "callback capturing this should be "
+       "dispatched/deferred to a specific PID");
 
-  diag(lambda->getLocStart(), "callback capturing this should be "
-                              "dispatched/deferred to a specific PID");
+  // If the lambda was not declared at the site of the use add a note
+  // at its declaration.
+  if (ref && ref->getExprLoc() != lambda->getExprLoc()) {
+    diag(lambda->getExprLoc(), "declared here", DiagnosticIDs::Note);
+  }
 }
 
 } // namespace mesos

--- a/clang-tidy/mesos/ThisCaptureCheck.h
+++ b/clang-tidy/mesos/ThisCaptureCheck.h
@@ -16,7 +16,7 @@ namespace clang {
 namespace tidy {
 namespace mesos {
 
-/// FIXME: Write a short description.
+/// Catch potentially dangerous use of lambdas capturing `this`.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/mesos-this-capture.html

--- a/test/clang-tidy/mesos-this-capture.cpp
+++ b/test/clang-tidy/mesos-this-capture.cpp
@@ -12,10 +12,13 @@ struct Future {
 template <typename F>
 Future<Nothing> defer(int /*pid*/, F) { return {}; }
 
+template <typename PID, typename Iterate, typename Body>
+Future<Nothing> loop(const PID &pid, Iterate &&iterate, Body &&body) { return {}; }
 } // namespace process  {
 
 using process::Future;
 using process::defer;
+using process::loop;
 
 struct S {
   Future<Nothing> future() const { return {}; }
@@ -39,6 +42,23 @@ struct S {
     }
 };
 
+struct P {
+  Future<Nothing> future() const { return {}; }
+
+  void f() {
+    // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop(this, [this]() { (void)this; }, []() {});
+    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop(this, []() {}, [this]() { (void)this; });
+
+    auto l = [this]() { (void)this; };
+    // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop(this, l, []() {});
+    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop(this, []() {}, l);
+  }
+};
+
 // Negatives.
 void f() {
   Future<Nothing>().onAny([]() {});
@@ -55,3 +75,10 @@ struct K {
       future.onAny(l);
     }
 };
+
+void g() {
+  K k;
+  loop(k, []() {}, []() {});
+  loop(k, [k]() {}, []() {});
+  loop(k, []() {}, [k]() {});
+}

--- a/test/clang-tidy/mesos-this-capture.cpp
+++ b/test/clang-tidy/mesos-this-capture.cpp
@@ -1,14 +1,16 @@
 // RUN: %check_clang_tidy %s mesos-this-capture %t
 
+struct Nothing {};
+
 namespace process {
 template <typename>
 struct Future {
-  template <typename F> Future onAny(F) { return {}; };
-  template <typename F> Future then(F) { return {}; };
+  template <typename AnyCallback>
+  Future onAny(AnyCallback &&) { return {}; };
 };
 
 template <typename F>
-Future<void> defer(int pid, F) { return {}; }
+Future<Nothing> defer(int /*pid*/, F) { return {}; }
 
 } // namespace process  {
 
@@ -16,14 +18,9 @@ using process::Future;
 using process::defer;
 
 struct S {
-  Future<void> future() const { return {}; }
-
-  // TODO(bbannier): Rework matcher to check all branches of a chained Future.
+  Future<Nothing> future() const { return {}; }
 
   void f() {
-    future()
-        // CHECK-MESSAGES: :[[@LINE+1]]:15: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-        .then([this]() { (void)this; });
     future()
         // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
         .onAny([this]() { (void)this; });
@@ -31,32 +28,30 @@ struct S {
 
     void g() {
       future()
-          // CHECK-MESSAGES: :[[@LINE+1]]:17: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-          .then([=]() { (void)this; });
-      future()
           // CHECK-MESSAGES: :[[@LINE+1]]:18: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-          .onAny([=]() { (void)this->i; });
+          .onAny([=]() { (void)this; });
     }
 
-    // TODO(bbannier): Check referenced lambda.
-    // void h() {
-    //   auto l = [=]() { (void)this; };
-    //   // DISABLEDCHECK-MESSAGES: :[[@LINE+1]]:21: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    //   future().then(l);
-    // }
-
-    int i = 0;
+    void h() {
+      auto l = [=]() { (void)this; };
+      // CHECK-MESSAGES: :[[@LINE+1]]:22: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+      future().onAny(l);
+    }
 };
 
 // Negatives.
 void f() {
-  Future<void>().onAny([]() {});
-  Future<void>().then([]() {});
+  Future<Nothing>().onAny([]() {});
 };
 
 struct K {
     void f() {
-      Future<void>()
-          .then(defer(0, [=]() { (void)this; }));
+      auto future = Future<Nothing>();
+
+      future
+          .onAny(defer(0, [=]() { (void)this; }));
+
+      auto l = []() {};
+      future.onAny(l);
     }
 };


### PR DESCRIPTION
This PR implements a number of fixes and improvements for `mesos-this-capture`:
* implement a documentation FIXME
* do not use unconstrained traversal matchers like `hasAncestor` or `hasDescendent`; this reduces false positives
* also catch lambdas passed to `process::loop` if they capture `this` and are undeferred.