### PR TITLE
Added checker catching some ignored return types.

### DIFF
--- a/clang-tidy/mesos/CMakeLists.txt
+++ b/clang-tidy/mesos/CMakeLists.txt
@@ -5,6 +5,7 @@ add_clang_library(clangTidyMesosModule
   MesosTidyModule.cpp
   NamespaceCommentCheck.cpp
   ThisCaptureCheck.cpp
+  UnusedReturnValueCheck.cpp
 
   LINK_LIBS
   clangAST

--- a/clang-tidy/mesos/MesosTidyModule.cpp
+++ b/clang-tidy/mesos/MesosTidyModule.cpp
@@ -10,6 +10,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+#include "UnusedReturnValueCheck.h"
 
 #include "FlagsInheritanceCheck.h"
 #include "NamespaceCommentCheck.h"
@@ -27,6 +28,11 @@ public:
     CheckFactories.registerCheck<NamespaceCommentCheck>(
         "mesos-namespace-comment");
     CheckFactories.registerCheck<ThisCaptureCheck>("mesos-this-capture");
+
+    // TODO(bbannier): Graduate this checker from alpha once the code base is
+    // cleaned up.
+    CheckFactories.registerCheck<UnusedReturnValueCheck>(
+        "alpha-mesos-unused-return-value");
   }
 };
 

--- a/clang-tidy/mesos/UnusedReturnValueCheck.cpp
+++ b/clang-tidy/mesos/UnusedReturnValueCheck.cpp
@@ -1,0 +1,60 @@
+//===--- UnusedReturnValueCheck.cpp - clang-tidy---------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "UnusedReturnValueCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+UnusedReturnValueCheck::UnusedReturnValueCheck(StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      RawTypes(Options.getLocalOrGlobal("Types", "Try,Result")) {
+  StringRef(RawTypes).split(Types, ",", -1, false);
+}
+
+void UnusedReturnValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "Types", RawTypes);
+}
+
+void UnusedReturnValueCheck::registerMatchers(MatchFinder *Finder) {
+  for (auto &&type : Types) {
+    auto returnValue =
+        callExpr(hasDeclaration(functionDecl(returns(hasDeclaration(
+                                                 namedDecl(hasName(type)))))
+                                    .bind("function_decl")))
+            .bind("call");
+
+    // For trivial types an ignored return value would be a `callExpr` directly
+    // below a `compoundStmt`; otherwise an extra `cxxBindTemporaryExpr` and
+    // `exprWithCleanups` are created.
+    Finder->addMatcher(
+        compoundStmt(eachOf(has(returnValue),
+                            has(exprWithCleanups(
+                                has(cxxBindTemporaryExpr(has(returnValue))))))),
+        this);
+  }
+}
+
+void UnusedReturnValueCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *call = Result.Nodes.getNodeAs<CallExpr>("call");
+  const auto *function_decl =
+      Result.Nodes.getNodeAs<FunctionDecl>("function_decl");
+
+  diag(call->getLocStart(), "%0 returns a %1 which should not be ignored")
+      << function_decl << function_decl->getReturnType();
+}
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang

--- a/clang-tidy/mesos/UnusedReturnValueCheck.h
+++ b/clang-tidy/mesos/UnusedReturnValueCheck.h
@@ -1,0 +1,44 @@
+//===--- UnusedReturnValueCheck.h - clang-tidy-------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_UNUSED_RETURN_VALUE_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_UNUSED_RETURN_VALUE_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+/// Check if certain return values of certain types are ignored.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/mesos-unused-return-value.html
+class UnusedReturnValueCheck : public ClangTidyCheck {
+public:
+  UnusedReturnValueCheck(StringRef Name, ClangTidyContext *Context);
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+
+private:
+  const std::string RawTypes;
+  SmallVector<StringRef, 5> Types;
+};
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_UNUSED_RETURN_VALUE_H

--- a/docs/clang-tidy/checks/list.rst
+++ b/docs/clang-tidy/checks/list.rst
@@ -52,6 +52,7 @@ Clang-Tidy Checks
    llvm-twine-local
    mesos-flags-inheritance
    mesos-this-capture
+   mesos-unused-return-value
    misc-argument-comment
    misc-assert-side-effect
    misc-bool-pointer-implicit-conversion

--- a/docs/clang-tidy/checks/mesos-unused-return-value.rst
+++ b/docs/clang-tidy/checks/mesos-unused-return-value.rst
@@ -1,0 +1,26 @@
+.. title:: clang-tidy - mesos-unused-return-value
+
+mesos-unused-return-value
+==================
+
+In Mesos exceptions are not used; instead functions return union types like
+`Try` or `Result` and explicitly handle possible failure state. In this pattern
+failure states are explicit in the type system (via the function signature),
+but to be effective callers also need to handle function return values.
+
+The following example is either broken or brittle,
+
+    Try<Nothing> createFile(const Path&);
+
+    // Broken as code might continue even though file might not exist.
+    createFile("/foo/bar");
+
+and should instead explicitly handle failure state, e.g.,
+
+    Try<Nothing> created = createFile("/foo/bar");
+
+    if (created.isError()) { return Error(created.error()); }
+
+This check by default checks return values for functions returning `Try` and
+`Result`. An alternative list of types can be configured via the checker's
+`Types` config parameter.

--- a/test/clang-tidy/mesos-unused-return-value.cpp
+++ b/test/clang-tidy/mesos-unused-return-value.cpp
@@ -1,0 +1,55 @@
+// RUN: %check_clang_tidy %s alpha-mesos-unused-return-value %t
+
+template <typename T>
+struct Try {
+  Try() = default;
+  Try(Try &&) = default;
+  Try(T) {}
+  Try &operator=(const Try &) = default;
+  ~Try() = default;
+};
+
+Try<int> f() {
+  f();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'f' returns a 'Try<int>' which should not be ignored [alpha-mesos-unused-return-value]
+
+  Try<int> t;
+  t = f();
+  t = (f());
+  t = Try<int>(f());
+  return f();
+}
+
+struct F {
+  static Try<int> f() {
+    f();
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'f' returns a 'Try<int>' which should not be ignored [alpha-mesos-unused-return-value]
+    return f();
+  }
+};
+
+struct G {
+  G() = default;
+  ~G() = default;
+  static Try<G> f() {
+    f();
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'f' returns a 'Try<G>' which should not be ignored [alpha-mesos-unused-return-value]
+    return f();
+  }
+};
+
+void g() {
+  auto ff = []() -> Try<int> { return 0; };
+  ff();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator()' returns a 'Try<int>' which should not be ignored [alpha-mesos-unused-return-value]
+}
+
+Try<int> j() {
+  Try<int> foo = j();
+  return j();
+}
+
+int k() {
+    k();
+    return k();
+}


### PR DESCRIPTION
This checker is intended to catch instances where a function returning
e.g., a `Try<Nothing>` is called, but the return value is not examined
for errors.

The checker is added under the `alpha-mesos` prefix as it produces *a
lot* of diagnostics and is e.g., not enabled in the mesos-tidy setup. This
is to make sure we do not hide other warning types at the moment.