### PR TITLE
Revert diagnosing of this capture in process loop callbacks

### DIFF
--- a/clang-tidy/mesos/ThisCaptureCheck.cpp
+++ b/clang-tidy/mesos/ThisCaptureCheck.cpp
@@ -70,13 +70,6 @@ void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
           on(hasType(cxxRecordDecl(hasName("Future")))),
           hasAnyArgument(anyOf(lambdaCapturingThis, lambdaCapturingThisRef))),
       this);
-
-  // Matcher for `process::loop`.
-  Finder->addMatcher(callExpr(callee(namedDecl(hasName("process::loop"))),
-                              hasAnyArgument(anyOf(
-                                  materializeTemporaryExpr(lambdaCapturingThis),
-                                  lambdaCapturingThisRef))),
-                     this);
 }
 
 void ThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {

--- a/test/clang-tidy/mesos-this-capture.cpp
+++ b/test/clang-tidy/mesos-this-capture.cpp
@@ -12,13 +12,10 @@ struct Future {
 template <typename F>
 Future<Nothing> defer(int /*pid*/, F) { return {}; }
 
-template <typename PID, typename Iterate, typename Body>
-Future<Nothing> loop(const PID &pid, Iterate &&iterate, Body &&body) { return {}; }
 } // namespace process  {
 
 using process::Future;
 using process::defer;
-using process::loop;
 
 struct S {
   Future<Nothing> future() const { return {}; }
@@ -42,23 +39,6 @@ struct S {
     }
 };
 
-struct P {
-  Future<Nothing> future() const { return {}; }
-
-  void f() {
-    // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, [this]() { (void)this; }, []() {});
-    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, []() {}, [this]() { (void)this; });
-
-    auto l = [this]() { (void)this; };
-    // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, l, []() {});
-    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, []() {}, l);
-  }
-};
-
 // Negatives.
 void f() {
   Future<Nothing>().onAny([]() {});
@@ -75,10 +55,3 @@ struct K {
       future.onAny(l);
     }
 };
-
-void g() {
-  K k;
-  loop(k, []() {}, []() {});
-  loop(k, [k]() {}, []() {});
-  loop(k, []() {}, [k]() {});
-}


### PR DESCRIPTION
The check as implemented here does not trigger on the correct pattern; instead, it will incorrectly trigger for _all_ uses of `this`-capturing lambdas in callbacks passed to `process::loop` with no regard whether these uses are dubious. This makes this particular variant of the check a source of noise.

To be correct we should trigger on uses of `loop` where we execute on some actor not controlling the lifetime of pointers stored in callbacks (but, if we e.g., executed on `self()`, capturing `this` would be safe and never diagnosed). The implementation for that would require more control flow analysis than currently implemented. Rolling back this patch until we come up with a solution with better signal to noise ratio.