### PR TITLE
Tightened this-capture check.

### DIFF
--- a/clang-tidy/mesos/ThisCaptureCheck.cpp
+++ b/clang-tidy/mesos/ThisCaptureCheck.cpp
@@ -71,12 +71,16 @@ void ThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
           hasAnyArgument(anyOf(lambdaCapturingThis, lambdaCapturingThisRef))),
       this);
 
-  // Matcher for `process::loop`.
-  Finder->addMatcher(callExpr(callee(namedDecl(hasName("process::loop"))),
-                              hasAnyArgument(anyOf(
-                                  materializeTemporaryExpr(lambdaCapturingThis),
-                                  lambdaCapturingThisRef))),
-                     this);
+  // Matcher for `process::loop`. This function has two overloads, a
+  // two-argument version taking just lambdas and a three-argument one also
+  // taking a PID to dispatch to. We only check the two-argument version and
+  // assume that the version taking a PID is internally sound.
+  Finder->addMatcher(
+      callExpr(
+          argumentCountIs(2), callee(namedDecl(hasName("process::loop"))),
+          hasAnyArgument(anyOf(materializeTemporaryExpr(lambdaCapturingThis),
+                               lambdaCapturingThisRef))),
+      this);
 }
 
 void ThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {

--- a/test/clang-tidy/mesos-this-capture.cpp
+++ b/test/clang-tidy/mesos-this-capture.cpp
@@ -12,8 +12,8 @@ struct Future {
 template <typename F>
 Future<Nothing> defer(int /*pid*/, F) { return {}; }
 
-template <typename PID, typename Iterate, typename Body>
-Future<Nothing> loop(const PID &pid, Iterate &&iterate, Body &&body) { return {}; }
+template <typename Iterate, typename Body>
+Future<Nothing> loop(Iterate &&iterate, Body &&body) { return {}; }
 } // namespace process  {
 
 using process::Future;
@@ -46,16 +46,16 @@ struct P {
   Future<Nothing> future() const { return {}; }
 
   void f() {
-    // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, [this]() { (void)this; }, []() {});
-    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, []() {}, [this]() { (void)this; });
+    // CHECK-MESSAGES: :[[@LINE+1]]:10: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop([this]() { (void)this; }, []() {});
+    // CHECK-MESSAGES: :[[@LINE+1]]:19: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop([]() {}, [this]() { (void)this; });
 
     auto l = [this]() { (void)this; };
-    // CHECK-MESSAGES: :[[@LINE+1]]:16: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, l, []() {});
-    // CHECK-MESSAGES: :[[@LINE+1]]:25: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
-    loop(this, []() {}, l);
+    // CHECK-MESSAGES: :[[@LINE+1]]:10: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop(l, []() {});
+    // CHECK-MESSAGES: :[[@LINE+1]]:19: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
+    loop([]() {}, l);
   }
 };
 
@@ -78,7 +78,7 @@ struct K {
 
 void g() {
   K k;
-  loop(k, []() {}, []() {});
-  loop(k, [k]() {}, []() {});
-  loop(k, []() {}, [k]() {});
+  loop([]() {}, []() {});
+  loop([k]() {}, []() {});
+  loop([]() {}, [k]() {});
 }


### PR DESCRIPTION
This patch cleans up false positives of the `mesos-this-capture` check in `process::loop` use.

Since actually diagnosing incorrect use of `this` captures with `process::loop` requires control flow analysis beyond the scope of tidy checkers we instead whitelist use of `defer`/`dispatch`-less lambdas in the `process::loop` overload taking a `PID` and assume that it is internally consistent. Unrelated to this change we should probably modify that overload to not take an `Option<PID>` anymore, but instead always to make sure we can always safely dispatch when provided a `PID` and also identify problematic code by just looking at the overload.

With this change all the current false positives due to `mesos-this-capture` disappear and we are left with only a true positive

    /home/bbannier/src/mesos/src/slave/containerizer/mesos/provisioner/provisioner.cpp:568:11: warning: callback capturing this should be dispatched/deferred to a specific PID [mesos-this-capture]
        .then([=]() -> Future<ProvisionInfo> {
              ^

This branch should be mergeable as a fast-forward merge.