### PR TITLE
[clang-tidy] Added a check for redundant get use.

### DIFF
--- a/clang-tidy/mesos/CMakeLists.txt
+++ b/clang-tidy/mesos/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS support)
 add_clang_library(clangTidyMesosModule
   FlagsInheritanceCheck.cpp
   MesosTidyModule.cpp
+  RedundantGetCheck.cpp
   NamespaceCommentCheck.cpp
   ThisCaptureCheck.cpp
 

--- a/clang-tidy/mesos/MesosTidyModule.cpp
+++ b/clang-tidy/mesos/MesosTidyModule.cpp
@@ -10,6 +10,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+#include "RedundantGetCheck.h"
 
 #include "FlagsInheritanceCheck.h"
 #include "NamespaceCommentCheck.h"
@@ -24,6 +25,8 @@ public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
     CheckFactories.registerCheck<FlagsInheritanceCheck>(
         "mesos-flags-inheritance");
+    CheckFactories.registerCheck<RedundantGetCheck>(
+        "mesos-redundant-get");
     CheckFactories.registerCheck<NamespaceCommentCheck>(
         "mesos-namespace-comments");
     CheckFactories.registerCheck<ThisCaptureCheck>("mesos-this-capture");

--- a/clang-tidy/mesos/RedundantGetCheck.cpp
+++ b/clang-tidy/mesos/RedundantGetCheck.cpp
@@ -1,0 +1,60 @@
+//===--- RedundantGetCheck.cpp - clang-tidy--------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "RedundantGetCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+void RedundantGetCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      memberExpr(
+          has(ignoringImpCasts(
+              cxxMemberCallExpr(
+                  callee(cxxMethodDecl(hasName("get"))),
+                  on(expr(hasType(cxxRecordDecl(anyOf(
+                              hasName("::process::Future"), hasName("::Option"),
+                              hasName("::Try"), hasName("::Result")))))
+                         .bind("wrapper")))
+                  .bind("get"))),
+          unless(anyOf(isArrow(), hasDeclaration(cxxConversionDecl()))))
+          .bind("member"),
+      this);
+}
+
+void RedundantGetCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *get = Result.Nodes.getNodeAs<CXXMemberCallExpr>("get");
+  const auto *wrapper = Result.Nodes.getNodeAs<Expr>("wrapper");
+  const auto *member = Result.Nodes.getNodeAs<MemberExpr>("member");
+
+  // Do not diagnose cases where the `get` and member accessed via its return
+  // value do not have the same `FileID`. This e.g., suppresses cases where the
+  // `get` was part of a macro argument, but the member access was in a macro
+  // definition like in uses of `EXPECT_NONE` and similar macros.
+  if (Result.SourceManager->getDecomposedLoc(get->getRParenLoc()).first !=
+      Result.SourceManager->getDecomposedLoc(member->getExprLoc()).first)
+    return;
+
+  StringRef replacement = Lexer::getSourceText(
+      CharSourceRange::getTokenRange(wrapper->getSourceRange()),
+      *Result.SourceManager, getLangOpts());
+
+  diag(get->getExprLoc(), "use of redundant 'get'")
+      << FixItHint::CreateReplacement(member->getOperatorLoc(), "->")
+      << FixItHint::CreateReplacement(get->getSourceRange(), replacement);
+}
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang

--- a/clang-tidy/mesos/RedundantGetCheck.h
+++ b/clang-tidy/mesos/RedundantGetCheck.h
@@ -1,0 +1,41 @@
+//===--- RedundantGetCheck.h - clang-tidy------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_REDUNDANT_GET_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_REDUNDANT_GET_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace mesos {
+
+// Find and remove redundant calls to `.get()` on stout and libprocess wrapper
+// types.
+
+// Examples:
+
+// \code
+//   Option<vector<int>> option;
+
+//   option.get().empty() ==> option->empty()
+// \endcode
+class RedundantGetCheck : public ClangTidyCheck {
+public:
+  RedundantGetCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace mesos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MESOS_REDUNDANT_GET_H

--- a/docs/clang-tidy/checks/list.rst
+++ b/docs/clang-tidy/checks/list.rst
@@ -77,6 +77,7 @@ Clang-Tidy Checks
    llvm-namespace-comment
    llvm-twine-local
    mesos-flags-inheritance
+   mesos-redundant-get
    mesos-this-capture
    misc-argument-comment
    misc-assert-side-effect

--- a/docs/clang-tidy/checks/mesos-redundant-get.rst
+++ b/docs/clang-tidy/checks/mesos-redundant-get.rst
@@ -1,0 +1,16 @@
+.. title:: clang-tidy - mesos-redundant-get
+
+mesos-redundant-get
+===================
+
+Find and remove redundant calls to ``.get()`` on stout and libprocess wrapper
+types. This check currently handles ``Future``, ``Option``, ``Try``, and
+``Result``.
+
+Examples:
+
+.. code-block:: c++
+
+  Option<vector<int>> option;
+
+  option.get().empty() ==> option->empty()

--- a/test/clang-tidy/mesos-redundant-get.cpp
+++ b/test/clang-tidy/mesos-redundant-get.cpp
@@ -1,0 +1,122 @@
+// RUN: %check_clang_tidy %s mesos-redundant-get %t
+
+struct Foo {
+  void bar();
+  int baz;
+  void quz() const;
+};
+
+namespace process {
+template <typename T>
+struct Future {
+  T *operator->();
+  T &get();
+
+  const T *operator->() const;
+  const T &get() const;
+        };
+}
+
+template <typename T>
+using Option = process::Future<T>;
+
+template <typename T>
+using Try = process::Future<T>;
+
+// Positives.
+void p1(process::Future<Foo> p) {
+
+  // CHECK-MESSAGES: :[[@LINE+2]]:5: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: p->bar();
+  p.get().bar();
+
+  // CHECK-MESSAGES: :[[@LINE+2]]:11: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: p->quz();
+  (void)p.get().quz();
+
+  // CHECK-MESSAGES: :[[@LINE+2]]:11: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: p->baz;
+  (void)p.get().baz;
+}
+
+void p2(const process::Future<Foo> p) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:11: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: p->quz();
+  (void)p.get().quz();
+
+  // CHECK-MESSAGES: :[[@LINE+2]]:11: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: p->baz;
+  (void)p.get().baz;
+}
+
+#define EXPECT_NONE(option) option.baz;
+
+void p3(process::Future<Option<Foo>> p) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:17: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: EXPECT_NONE(p->get());
+  EXPECT_NONE(p.get().get());
+}
+
+using TryFoo = Try<Foo>;
+void p4(process::Future<TryFoo> p) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:17: warning: use of redundant 'get' [mesos-redundant-get]
+  // CHECK-FIXES: EXPECT_NONE(p->get());
+  EXPECT_NONE(p.get().get());
+}
+
+// Negatives.
+void n1(process::Future<Foo> n) {
+  n.get();
+  n->bar();
+  n->quz();
+  (void)n->baz;
+}
+
+void n2(const process::Future<Foo> n) {
+  n.get();
+  n->quz();
+  (void)n->baz;
+}
+
+void n3(process::Future<Foo *> n) {
+  n.get()->bar();
+  n.get()->quz();
+  (void)n.get()->baz;
+}
+
+template <typename T>
+struct Other {
+  T get();
+};
+
+void n4(Other<Foo> n) {
+  (void)n.get().bar();
+  (void)n.get().quz();
+  (void)n.get().baz;
+}
+
+struct Conv {
+  operator int() const { return {}; }
+};
+
+void n5(process::Future<Conv> n) {
+  int ni = n.get();
+}
+
+#define EXPECT_NONE(option) option.get();
+
+void n6(process::Future<Option<int>> n) {
+  EXPECT_NONE(n.get());
+}
+
+void n7() {
+  // A future not defined in the `process` namespace.
+  struct Future {
+    struct Int {
+      int value() const { return {}; }
+    };
+    const Int &get() const { return {}; }
+  } n;
+
+  int ni = n.get().value();
+}


### PR DESCRIPTION
This commit adds a `clang-tidy` check catching undesirable use of `get()` on `Option<T>` and similar types. We also add fix-its.

The check has been tested on the Mesos code and produces no false positives or false negatives there in reachable code.